### PR TITLE
Patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
     - CONDA_PY=27
-    - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "ODmNwdMU2qNUk7ADcALzyUUl3JKQLJK7Q0t9T/h/Mz9/uDE7kWic4AgYISBKCEHUI5XXGoK5+30Y5uosT0KvR2rAiC7pUmwFZkIFGoRcxAGqB2HXZF7C0eXd6OSC0wxiHX9I8KHaRq7LU5oeUrb1O524M2bh7qMK887rj9F6IrN01aE28FJMePBkZ+xLDZYunmWVB3K7PWaY/MkyEjl+9I6d9xeoqwKfToODqHgJ3x3KdGJz27s4/xxys1DOg4gfOQu3S5uznuo6k68+bIf6SYM0KTLKIquqpOQfFUNHesbeE8R+cliwD27t9fiQ01YxlMXGKQ50PUnft88ZD+uRl49ZQGDVuzuYYP7XC+rWRm2UsZ/8AEJE8VS5BvnUiSon7w2kWwousJVsjqLb/unnXTSBsX2wUaJZcoO40hXKb/+7L4IY/YfIi+lIlMLWdApURZdfU2bh9kUxr0EUdF4Xa7w+HYXfqq0nQIFZDRiEYwflzbCNQ+puqkv6CY0puOK39QpRzmpKa72P9Zwt1RssxL6L0hbSEPllRF7hkJJfwPBXMbJkOW95bQsRUO37+DTblrPW13LvM0VFuImfc242icJjv3GvcJ/WLaJGbn8FdKDJU2m3WA5tG4eKDEKjM9bcoYmEBf+2FojoHTpbqXflktj8MlB6votgGxJFHoozvQk="
@@ -19,7 +19,7 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
+    - brew remove --force --ignore-dependencies $(brew list)
     - brew cleanup -s
     - rm -rf $(brew --cache)
 
@@ -31,6 +31,8 @@ install:
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,19 +23,19 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
@@ -58,23 +58,19 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: set "OLDPATH="
-
-    # Actually activate `conda`.
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
+
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?
@@ -49,13 +49,13 @@ source run_conda_forge_build_setup
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_PY=34
+    export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_PY=35
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/charset.patch
+++ b/recipe/charset.patch
@@ -1,0 +1,17 @@
+--- Pydap-3.2.0.orig/src/pydap/handlers/dap.py	2016-12-01 18:03:54.000000000 -0300
++++ Pydap-3.2.0/src/pydap/handlers/dap.py	2017-01-27 15:41:47.993518399 -0300
+@@ -49,10 +49,14 @@
+         ddsurl = urlunsplit((scheme, netloc, path + '.dds', query, fragment))
+         r = GET(ddsurl, application, session)
+         raise_for_status(r)
++        if not r.charset:
++            r.charset = 'utf8'
+         dds = r.text
+ 
+         dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
+         r = GET(dasurl, application, session)
++        if not r.charset:
++            r.charset = 'utf8'
+         raise_for_status(r)
+         das = r.text
+ 

--- a/recipe/gunicorn.patch
+++ b/recipe/gunicorn.patch
@@ -1,0 +1,40 @@
+--- Pydap-3.2.0.orig/setup.py	2016-12-01 19:32:16.000000000 -0300
++++ Pydap-3.2.0/setup.py	2017-01-27 15:25:55.701470972 -0300
+@@ -10,7 +10,6 @@
+     'Webob',
+     'Jinja2',
+     'docopt',
+-    'gunicorn',
+     'six >= 1.4.0',
+     'mechanicalsoup',
+ ]
+@@ -24,6 +23,10 @@
+     'scipy',
+ ]
+ 
++server_extras = [
++    'gunicorn',
++]
++
+ docs_extras = [
+     'Sphinx',
+     'Pygments',
+@@ -34,7 +37,7 @@
+     'requests'
+     ]
+     
+-tests_require = functions_extras + cas_extras + [
++tests_require = functions_extras + cas_extras + server_extras + [
+     'WebTest',
+     'beautifulsoup4',
+     'scipy'
+@@ -80,7 +83,8 @@
+         'testing': testing_extras,
+         'docs': docs_extras,
+         'tests': tests_require,
+-        'cas': cas_extras
++        'cas': cas_extras,
++        'server': server_extras
+     },
+     test_suite="pydap.tests",
+     entry_points="""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 86dca669f84eecba6ff67af7fa3332af24a0163a72991d02452f4ca1f4d3f99f
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -24,18 +24,20 @@ requirements:
     - webob
     - jinja2
     - docopt
-    - gunicorn  # [not win]
     - six >=1.4.0
     - mechanicalsoup
-    # optional
+    # Server only.
+    - gunicorn  # [not win]
+    # Optional.
     - gsw
-    #- coards
     - scipy
     - requests
+    #- coards
 
 test:
   imports:
     - pydap
+    - pydap.client.open_url
 
 about:
   home: http://pydap.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
   fn: Pydap-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/P/Pydap/Pydap-{{ version }}.tar.gz
   sha256: 86dca669f84eecba6ff67af7fa3332af24a0163a72991d02452f4ca1f4d3f99f
+  patches:
+    - gunicorn.patch
+    - charset.patch
 
 build:
   number: 1
@@ -26,18 +29,17 @@ requirements:
     - docopt
     - six >=1.4.0
     - mechanicalsoup
-    # Server only.
-    - gunicorn  # [not win]
     # Optional.
     - gsw
     - scipy
     - requests
     #- coards
+    # Server only.
+    - gunicorn  # [not win]
 
 test:
   imports:
     - pydap
-    - pydap.client.open_url
 
 about:
   home: http://pydap.org/

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,9 @@
+from pydap.client import open_url
+
+# OPeNDAP.
+# TODO: charset issue with webop.
+#url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
+# works for now
+# gunicorn
+url = 'http://tds.marine.rutgers.edu/thredds/dodsC/roms/espresso/2013_da/his/ESPRESSO_Real-Time_v2_History_Best'
+ds = open_url(url)

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,9 +1,5 @@
 from pydap.client import open_url
 
-# OPeNDAP.
-# TODO: charset issue with webop.
-#url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
-# works for now
-# gunicorn
-url = 'http://tds.marine.rutgers.edu/thredds/dodsC/roms/espresso/2013_da/his/ESPRESSO_Real-Time_v2_History_Best'
+url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
+
 ds = open_url(url)


### PR DESCRIPTION
@rsignell-usgs I added two patches. Teh first one, [`gunicorn.patch`](https://github.com/ocefpaf/pydap-feedstock/blob/42842250669b732af75b22462e936166fa35bd5a/recipe/gunicorn.patch) solves the issue you reported in https://gist.github.com/rsignell-usgs/7c9cf9f88a2f0c920c1a4ee7d7eaf601
(There is no reason to force `gunicorn`, a server only dependency, to use `pydap` in client mode.)

The second patch solves an issue I found while testing this. If you try the test I added here,

```python
from pydap.client import open_url

url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
ds = open_url(url)
```

You will get an error complaining that the `charset` is not set. But according to `webop` own website most endpoints do have have set and we need to `default` to `utf-8`. [`charset.patch`](https://github.com/ocefpaf/pydap-feedstock/blob/42842250669b732af75b22462e936166fa35bd5a/recipe/charset.patch) fixes that too.

I will send those upstream but since we won't get a release anytime soon I am patching here and bumping the build number.

See https://github.com/pydap/pydap/pull/60 and https://github.com/pydap/pydap/pull/59