### PR TITLE
No patch to show the error

### DIFF
--- a/recipe/charset.patch
+++ b/recipe/charset.patch
@@ -5,13 +5,13 @@
          r = GET(ddsurl, application, session)
          raise_for_status(r)
 +        if not r.charset:
-+            r.charset = 'utf8'
++            r.charset = 'ascii'
          dds = r.text
  
          dasurl = urlunsplit((scheme, netloc, path + '.das', query, fragment))
          r = GET(dasurl, application, session)
 +        if not r.charset:
-+            r.charset = 'utf8'
++            r.charset = 'ascii'
          raise_for_status(r)
          das = r.text
  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 86dca669f84eecba6ff67af7fa3332af24a0163a72991d02452f4ca1f4d3f99f
   patches:
     - gunicorn.patch
-    #- charset.patch
+    - charset.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ source:
   sha256: 86dca669f84eecba6ff67af7fa3332af24a0163a72991d02452f4ca1f4d3f99f
   patches:
     - gunicorn.patch
-    - charset.patch
+    #- charset.patch
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
@jameshiebert I am committing here without the patch to show the error and then I will modify the patch to `ascii` instead of `utf-8` since that seems to be the standard for OPeNDAP.