### PR TITLE
New 3.5.4 release.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pydap" %}
-{% set version = "3.5.3" %}
+{% set version = "3.5.4" %}
 {% set python_min = "3.10" %}
 
 # handle undefined PYTHON in `noarch: python` outputs
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pydap-{{ version }}.tar.gz
-  sha256: 08964ad6f279865814aa134cde36c3d8957de790759b3485cffce41443a9db54
+  sha256: 1ff6f783b6305a02ccd6e80fd4570b3db2be85435f00ddc827e821f32694df99
 
 build:
   noarch: python
@@ -30,13 +30,16 @@ outputs:
         - pip
       run:
         - python >={{ python_min }}
-        - numpy >=2.0
+        - numpy
         - requests
+        - requests-cache
         - scipy
+        - webob
+        - beautifulsoup4
+        - lxml
         # optional, server, but required to pass the import test
         - docopt-ng
         - jinja2
-        - webob
     test:
       imports:
         - pydap
@@ -60,7 +63,6 @@ outputs:
       run:
         - python >={{ python_min }}
         - {{ pin_subpackage("pydap", exact=True) }}
-        - beautifulsoup4
         - docopt-ng
         - gunicorn
         - jinja2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

I did not re-rendered with conda-smithy. I was unsure what such re-render would do to the two outputs associated with this pydap-feedstock: `pydap` and `pydap-server`. In this new version, the dependencies changed on the pyproject.toml:

```python
- requests-cache
```
was added.

In this PR, I manually added the dependencies to the `pydap` output on the meta.yaml file, to match one-to-one, the dependencies listed on pydap's pyproject.toml:
https://github.com/pydap/pydap/blob/13e1b07040e0466e099eb8e7e2633195d08647d2/pyproject.toml#L22-L29
<!--
Please add any other relevant info below:
-->
